### PR TITLE
bulild enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# virtualenv setup
+/bin
+/lib/python*
+/include/python*
+/.Python

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ nosetests.xml
 
 # vscode noise
 /.vscode/c_cpp_properties.json
+
+# pytest cache
+/.pytest_cache
+
+# setuptools setup_requires eggs
+/.eggs

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ nosetests.xml
 /lib/python*
 /include/python*
 /.Python
+
+# vscode noise
+/.vscode/c_cpp_properties.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,3 +63,19 @@ matrix:
       name: cp37-win_amd64
       language: shell
       install: source travis/setup_cibuildwheel_env.windows.sh 3.7.4
+    - os: windows
+      name: cp27-win32
+      language: shell
+      install: source travis/setup_cibuildwheel_env.windows.sh 2.7.16 32
+    - os: windows
+      name: cp35-win32
+      language: shell
+      install: source travis/setup_cibuildwheel_env.windows.sh 3.5.4 32
+    - os: windows
+      name: cp36-win32
+      language: shell
+      install: source travis/setup_cibuildwheel_env.windows.sh 3.6.8 32
+    - os: windows
+      name: cp37-win32
+      language: shell
+      install: source travis/setup_cibuildwheel_env.windows.sh 3.7.4 32

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ git:
 env:
   global:
     - CIBW_BEFORE_BUILD='bash travis/cibw_before_build.sh'
-    - CIBW_TEST_COMMAND='python {project}/test/test_smoke.py'
+    - CIBW_TEST_REQUIRES=pytest
+    - CIBW_TEST_COMMAND='pytest {project}'
     - CIBW_ENVIRONMENT_LINUX=TRAVIS_OS_NAME=${TRAVIS_OS_NAME}
 script:
   - python -m pip install --upgrade pip wheel cibuildwheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,21 +35,18 @@ matrix:
       name: cp37-macosx
       language: shell
       env: CIBW_BUILD='cp37-*'
-    # - os: osx
-    #   name: cp36-macosx
-    #   language: shell
-    #   install: HOMEBREW_NO_AUTO_UPDATE=1 brew install libsndfile portaudio
-    #   env: CIBW_BUILD='cp36-*'
-    # - os: osx
-    #   name: cp35-macosx
-    #   language: shell
-    #   install: HOMEBREW_NO_AUTO_UPDATE=1 brew install libsndfile portaudio
-    #   env: CIBW_BUILD='cp35-*'
-    # - os: osx
-    #   name: cp34-macosx
-    #   language: shell
-    #   install: HOMEBREW_NO_AUTO_UPDATE=1 brew install libsndfile portaudio
-    #   env: CIBW_BUILD='cp34-*'
+    - os: osx
+      name: cp36-macosx
+      language: shell
+      env: CIBW_BUILD='cp36-*'
+    - os: osx
+      name: cp35-macosx
+      language: shell
+      env: CIBW_BUILD='cp35-*'
+    - os: osx
+      name: cp34-macosx
+      language: shell
+      env: CIBW_BUILD='cp34-*'
     # - os: windows
     #   name: cp27-win_amd64
     #   language: shell

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "python.testing.autoTestDiscoverOnSaveEnabled": false
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestPath": "${workspaceFolder}/bin/pytest",
+    "python.linting.pep8Enabled": true,
+    "python.linting.pep8Path": "${workspaceFolder}/bin/pep8",
+    "python.linting.pep8Args": ["--max-line-length=120" ],
+    "python.pythonPath": "${workspaceFolder}/bin/python"
 }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,8 @@
-include AUTHORS
-include COPYING
-include INSTALL
-include NEWS
-include USAGE
-recursive-include lib/build *
+include AUTHORS.md
+include COPYING.md
+include INSTALL.md
+include NEWS.md
+include USAGE.md
 include lib/include/*.h
-include lib/lib/*
 include lib/src/*.h
 include symbols.lst

--- a/lib/src/medussa_callbacks.c
+++ b/lib/src/medussa_callbacks.c
@@ -92,11 +92,13 @@ static double half_hann(unsigned index, unsigned total) {
 
 void increment_mix_mat_fade( stream_user_data *sud )
 {
+    unsigned index;
+    int cosine;
     if( sud->mix_mat_fade_countdown_frames == 0 )
         return;
 
-    unsigned index = sud->mix_mat_fade_total_frames - sud->mix_mat_fade_countdown_frames;
-    int cosine = (sud->flags & STREAM_FLAG_COSINE_FADE);
+    index = sud->mix_mat_fade_total_frames - sud->mix_mat_fade_countdown_frames;
+    cosine = (sud->flags & STREAM_FLAG_COSINE_FADE);
     // debug("increment_mix_mat_fade index=%u total=%u cosine=%d",
     //         index, sud->mix_mat_fade_total_frames, cosine);
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+numpy >= 1.13 --only-binary=numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[aliases]
+test=pytest
+
+[tool:pytest]
+testpaths = test
+addopts = -rf
+
+[pep8]
+exclude = lib/python*,include/python*,build,bin

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ pymaj = platform.python_version_tuple()[0]
 pymin = platform.python_version_tuple()[1]
 pyver = "{}.{}".format(pymaj, pymin)
 
-sys.path.insert(0,os.path.abspath(r'./src'))
-docs =  __import__('docs', fromlist=['package_name', 'version', 'url',
-                    'author', 'author_email', 'long_help',
-                    'short_description', 'long_description', 'maintainer',
-                    'maintain_email', 'keywords', 'platforms'])
+sys.path.insert(0, os.path.abspath(r'./src'))
+docs = __import__('docs', fromlist=['package_name', 'version', 'url',
+                                    'author', 'author_email', 'long_help',
+                                    'short_description', 'long_description', 'maintainer',
+                                    'maintain_email', 'keywords', 'platforms'])
 del sys.path[0]
 
 medussa_package = [docs.package_name]
@@ -47,9 +47,9 @@ medussa_package_dir = 'src'
 medussa_package_data = ['*.py']
 medussa_data_files = ['symbols.lst']
 medussa_data_files_path = 'medussa'
-medussa_install_requires = ['numpy >=1.3']
-medussa_requires = ['numpy (>=1.3)',]
-medussa_setup_requires = ['numpy >=1.3']
+medussa_requires = ['numpy (>=1.3)']
+medussa_install_requires = medussa_requires
+medussa_setup_requires = medussa_requires + ['setuptools-pep8', 'pytest-runner']
 
 library_dirs = []
 libraries = ['portaudio', 'sndfile']
@@ -75,44 +75,46 @@ else:
     else:
         extra_compile_args += ["-DNDEBUG", "-O3"]
 
+
 def get_exported_symbols():
     return [l.strip() for l in open('symbols.lst')]
 
 
 cmedussa = Extension('.'.join([docs.package_name, 'libmedussa']),
-    include_dirs=[numpy.get_include(), 'lib', os.path.join('lib', 'include')],
-    libraries=libraries,
-    library_dirs=library_dirs,
-    language="c++",
-    export_symbols=get_exported_symbols(),
-    extra_compile_args=extra_compile_args,
-    sources=glob.glob(os.path.join('lib', 'src', '*.c')) +
-            glob.glob(os.path.join('lib', 'src', '*.cpp'))
-    )
+                     include_dirs=[numpy.get_include(), 'lib', os.path.join('lib', 'include')],
+                     libraries=libraries,
+                     library_dirs=library_dirs,
+                     language="c++",
+                     export_symbols=get_exported_symbols(),
+                     extra_compile_args=extra_compile_args,
+                     sources=(glob.glob(os.path.join('lib', 'src', '*.c')) +
+                              glob.glob(os.path.join('lib', 'src', '*.cpp')))
+                     )
 
 setup(name=docs.package_name,
-    version=docs.version,
-    description=docs.short_description,
-    author=docs.author,
-    author_email=docs.author_email,
-    maintainer = docs.maintainer,
-    maintainer_email = docs.maintainer_email,
-    url=docs.url,
-    packages = medussa_package,
-    include_package_data=True,
-    install_requires = medussa_install_requires,
-    setup_requires = medussa_setup_requires,
-    requires = medussa_requires,
-    eager_resources = ['setup.lst'],
-    package_dir={docs.package_name: medussa_package_dir},
-    package_data={docs.package_name: medussa_package_data},
-    data_files=[(medussa_data_files_path, medussa_data_files)],
-    keywords = docs.keywords,
-    license = docs.license,
-    platforms = docs.platforms,
-    long_description = docs.long_description,
-    ext_modules = [cmedussa],
-    classifiers=[
+      version=docs.version,
+      description=docs.short_description,
+      author=docs.author,
+      author_email=docs.author_email,
+      maintainer=docs.maintainer,
+      maintainer_email=docs.maintainer_email,
+      url=docs.url,
+      packages=medussa_package,
+      include_package_data=True,
+      install_requires=medussa_install_requires,
+      setup_requires=medussa_setup_requires,
+      requires=medussa_requires,
+      tests_require=['pytest>=2.8'],
+      eager_resources=['setup.lst'],
+      package_dir={docs.package_name: medussa_package_dir},
+      package_data={docs.package_name: medussa_package_data},
+      data_files=[(medussa_data_files_path, medussa_data_files)],
+      keywords=docs.keywords,
+      license=docs.license,
+      platforms=docs.platforms,
+      long_description=docs.long_description,
+      ext_modules=[cmedussa],
+      classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python",
         "Operating System :: Microsoft :: Windows",
@@ -134,4 +136,4 @@ setup(name=docs.package_name,
         "Topic :: Scientific/Engineering :: Physics",
         "Natural Language :: English",
         ],
-)
+      )

--- a/test/test_is_fading.py
+++ b/test/test_is_fading.py
@@ -11,20 +11,24 @@ import time
 import numpy as np
 import medussa as m
 
-d = m.open_default_device()
-tone = d.create_tone(500)
-tone.use_cosine_fades = True
-tone.mix_mat_fade_duration = 3.
 
-# Set up a dummy mix_mat array to work on
-silence_mix_mat = np.array([[0.0],[0.0]])
-full_volume_mix_mat = np.array([[1.0],[1.0]])
-tone.mix_mat = silence_mix_mat
+def main():
+    d = m.open_default_device()
+    tone = d.create_tone(500)
+    tone.use_cosine_fades = True
+    tone.mix_mat_fade_duration = 3.
 
-tone.play()
+    # Set up a dummy mix_mat array to work on
+    silence_mix_mat = np.array([[0.0], [0.0]])
+    full_volume_mix_mat = np.array([[1.0], [1.0]])
+    tone.mix_mat = silence_mix_mat
 
-tone.mix_mat = full_volume_mix_mat
+    tone.play()
 
+    tone.mix_mat = full_volume_mix_mat
 
-while True:
-    print("Hit ctrl-c to end -- tone.is_fading = {val}".format(val=tone.is_fading))
+    while True:
+        print("Hit ctrl-c to end -- tone.is_fading = {val}".format(val=tone.is_fading))
+
+if __name__ == " __main__":
+    main()

--- a/test/test_multichannel.py
+++ b/test/test_multichannel.py
@@ -2,8 +2,8 @@
 from __future__ import print_function
 
 """
-On multichannel hardware, this will play a tone and update mix_mat to simulate 
-motion. It will cycle through all the channels and loop back around again indefinitely. 
+On multichannel hardware, this will play a tone and update mix_mat to simulate
+motion. It will cycle through all the channels and loop back around again indefinitely.
 On stereo (2-channel) hardware, this results in left-right-left...
 """
 
@@ -11,38 +11,45 @@ import time
 import numpy as np
 import medussa as m
 
-d = m.open_default_device()
-tone = d.create_tone(500)
-tone.mix_mat_fade_duration = 1.
 
-# "Speaker array". For multichannel hardware, hardcode this with the number of 
-# actual channels on the device (medussa always sets this to 2 because 
-# portaudio reports this value unreliably. 
-sarray = range(d.out_channels)
-# Select first channel
-s = sarray[0]
-looping = True
-# Set up a dummy mix_mat array to work on
-mmlocal = np.array([[.25],[0.]])
-tone.mix_mat = mmlocal
-tone.play()
+def main():
+    d = m.open_default_device()
+    tone = d.create_tone(500)
+    tone.mix_mat_fade_duration = 1.
 
-print("Hit ctrl-c to end")
-
-# This loop turns on the next channel, turns off the current channel,
-# (wrapping when needed), and waits until fading is done.
-while looping:
-    print (s+1)
-    # Get next channel
-    s1 = s+1
-    if s1 > sarray[-1]: s1 = sarray[0]
-    # Turn next channel on
-    mmlocal[s1][0] = .25
-    # Turn last channel off
-    mmlocal[s][0] = 0.
-    # Update mix_mat
+    # "Speaker array". For multichannel hardware, hardcode this with the number of
+    # actual channels on the device (medussa always sets this to 2 because
+    # portaudio reports this value unreliably.
+    sarray = range(d.out_channels)
+    # Select first channel
+    s = sarray[0]
+    looping = True
+    # Set up a dummy mix_mat array to work on
+    mmlocal = np.array([[.25], [0.]])
     tone.mix_mat = mmlocal
-    # Wait for fade to finish
-    time.sleep(tone.mix_mat_fade_duration)
-    # Get ready for next channel
-    s = s1
+    tone.play()
+
+    print("Hit ctrl-c to end")
+
+    # This loop turns on the next channel, turns off the current channel,
+    # (wrapping when needed), and waits until fading is done.
+    while looping:
+        print(s+1)
+        # Get next channel
+        s1 = s+1
+        if s1 > sarray[-1]:
+            s1 = sarray[0]
+        # Turn next channel on
+        mmlocal[s1][0] = .25
+        # Turn last channel off
+        mmlocal[s][0] = 0.
+        # Update mix_mat
+        tone.mix_mat = mmlocal
+        # Wait for fade to finish
+        time.sleep(tone.mix_mat_fade_duration)
+        # Get ready for next channel
+        s = s1
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -5,45 +5,56 @@ import numpy as np
 from time import sleep
 import sys
 
-
-fs = 44100.0
-x,fs = medussa.read_file("test/clean.wav")
-#x,fs = medussa.read_file("test/speech-noise-tone.wav")
-
-#y = medussa.write_wav("test/clean2.wav", x, fs, bits='u8')
-#y = medussa.write_ogg("test/clean2.ogg", x, fs)
-#y = medussa.write_flac("test/clean2.flac", x, fs, bits=16)
-#flac16 = formats.SF_FORMAT_FLAC[0] | formats.SF_FORMAT_PCM_16[0]
-#oggv = formats.SF_FORMAT_OGG[0] | formats.SF_FORMAT_VORBIS[0]
-#y = medussa.writefile("test/clean2.ogg", x, fs, format=oggv)
-#print y
-
-d = medussa.open_device()
-dd = medussa.open_device()
-
-sleep(1)
-sa = d.open_array(x,fs)
-sf = d.open_file("test/clean.wav")
-st = d.create_tone(400,fs)
-sw = d.create_white(fs)
-sp = d.create_pink(fs)
-sp2 = dd.create_pink(fs)
-
-#medussa.write_wav('test/clean2.wav', x, fs)
+try:
+    # Python 2
+    xrange
+except NameError:
+    # Python 3, xrange is now named range
+    xrange = range
 
 
-def sweep_right(s, delta=0.001, steps=500):
-    s.play()
-    fade = np.linspace(0.0, 1.0, steps)
-    for i in xrange(steps):
-        s.mix_mat = np.array([1.0-fade[i], fade[i]])
-        sleep(delta)
-    s.pause()
+def main():
+    fs = 44100.0
+    x, fs = medussa.read_file("test/clean.wav")
+    # x,fs = medussa.read_file("test/speech-noise-tone.wav")
 
-def sweep_left(s, delta=0.001, steps=500):
-    s.play()
-    fade = np.linspace(0.0, 1.0, steps)
-    for i in xrange(steps):
-        s.mix_mat = np.array([fade[i], 1.0-fade[i]])
-        sleep(delta)
-    s.pause()
+    # y = medussa.write_wav("test/clean2.wav", x, fs, bits='u8')
+    # y = medussa.write_ogg("test/clean2.ogg", x, fs)
+    # y = medussa.write_flac("test/clean2.flac", x, fs, bits=16)
+    # flac16 = formats.SF_FORMAT_FLAC[0] | formats.SF_FORMAT_PCM_16[0]
+    # oggv = formats.SF_FORMAT_OGG[0] | formats.SF_FORMAT_VORBIS[0]
+    # y = medussa.writefile("test/clean2.ogg", x, fs, format=oggv)
+    # print y
+
+    d = medussa.open_device()
+    dd = medussa.open_device()
+
+    sleep(1)
+    sa = d.open_array(x, fs)
+    sf = d.open_file("test/clean.wav")
+    st = d.create_tone(400, fs)
+    sw = d.create_white(fs)
+    sp = d.create_pink(fs)
+    sp2 = dd.create_pink(fs)
+
+    # medussa.write_wav('test/clean2.wav', x, fs)
+
+    def sweep_right(s, delta=0.001, steps=500):
+        s.play()
+        fade = np.linspace(0.0, 1.0, steps)
+        for i in xrange(steps):
+            s.mix_mat = np.array([1.0 - fade[i], fade[i]])
+            sleep(delta)
+        s.pause()
+
+    def sweep_left(s, delta=0.001, steps=500):
+        s.play()
+        fade = np.linspace(0.0, 1.0, steps)
+        for i in xrange(steps):
+            s.mix_mat = np.array([fade[i], 1.0 - fade[i]])
+            sleep(delta)
+        s.pause()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -1,8 +1,10 @@
-from __future__ import print_function
-
 import medussa
 from os import path as _p
 
-# This will at least verify Python/C API binding works and .so loading after install
-x, fs = medussa.read_file(_p.join(_p.dirname(_p.abspath(__file__)), "clean.wav"))
-assert fs == 44100
+TEST_DIR = _p.dirname(_p.abspath(__file__))
+
+
+def test_smoke_read_file():
+    """This will at least verify Python/C API binding works and .so loading after install."""
+    x, fs = medussa.read_file(_p.join(TEST_DIR, "clean.wav"))
+    assert fs == 44100

--- a/travis/cibw_before_build.sh
+++ b/travis/cibw_before_build.sh
@@ -4,9 +4,7 @@
 set -eux
 set -o pipefail
 
-# Some platform-independent deps first
-# TODO cosider using requirements.txt for this?
-python -m pip install --upgrade --only-binary=numpy numpy
+python -m pip install -r requirements.txt
 
 OS_SCRIPT="travis/cibw_before_build.${TRAVIS_OS_NAME}.sh"
 [[ ! -x "${OS_SCRIPT}" ]] || "./${OS_SCRIPT}"


### PR DESCRIPTION
bunch of minor updates:
* instead of directly calling test_smoke.py as build verification, use pytest to run it, this will allow to add more pytest test easily without changing build scripts
* added pep8 support in setup.py script and made some files pep8-compliant while testing this
* use requirements.txt file for configuring build/development environment
* move some pytest and virtualenv-related paths to .gitignore
* extend build matrix to cover more binary release configurations (seems to make sense for uploading as many wheels to pypi automatically)
